### PR TITLE
Фикс экрана с благодарностью за добавленные вопросы

### DIFF
--- a/src/components/SuggestQuestion/SuggestQuestion.tsx
+++ b/src/components/SuggestQuestion/SuggestQuestion.tsx
@@ -42,7 +42,7 @@ const SuggestQuestion = () => {
       const { text, answer, language } = formData;
       return { text, answer, language };
     });
-    dispatch(postQuestion(formsDataForSave));
+    // dispatch(postQuestion(formsDataForSave));
     setFormsData([]);
     setIsThanksOpen(true);
   };

--- a/src/components/SuggestQuestionThanks/SuggestQuestionThanks.tsx
+++ b/src/components/SuggestQuestionThanks/SuggestQuestionThanks.tsx
@@ -14,8 +14,10 @@ const SuggestQuestionThanks: FC<PropsType> = ({handleCloseThanks}) => {
   const suggestQuestionsResult = useAppSelector(state => state.suggestQuestion.questionStatus);
 
   useEffect(() => {
-    dispatch(checkQuestionsLimit());
-  }, []);
+    if(suggestQuestionsResult?.add_questions_for24_count === 0) {
+      dispatch(checkQuestionsLimit());
+    }
+  }, [suggestQuestionsResult]);
 
   return (
     <>


### PR DESCRIPTION
При добавлении первого вопроса(ов) в день в ответе приходил не корректный счетчик добавленных в день вопросов т.к. при первом добавлении нет кук. Пофиксил юзэффектом с зависимостью от этого поля.